### PR TITLE
use merge-base in diffs

### DIFF
--- a/lib/feature.rb
+++ b/lib/feature.rb
@@ -21,9 +21,10 @@ module GitFlow
     end
 
     def _create_git(branch_name, repo)
-
-      @git_master = repo.branches[@master]
+      master_branch = repo.branches[@master]
       @git_branch = repo.branches["#{@remote_name}/#{branch_name}"]
+      
+      @git_master = repo.merge_base(@git_branch, master_branch)
 
       raise "Unable to find base branch: #{@master}"        if @git_master.nil?()
       raise "Unable to find feature branch: #{branch_name}" if @git_branch.nil?()


### PR DESCRIPTION
In the current implementation get_diff_files uses MASTER and FEATURE as references to diff.

If FEATURE is not rebased on the most current MASTER (which is likely), changes in the master branch are considered to be changes in FEATURE and are also imported into the feature-domain. Instead the code should use git merge-base (https://git-scm.com/docs/git-merge-base) (which is basically the fork point of the branch)