### PR TITLE
Change rubocop config: Set ruby target version to 2.3

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,7 @@
 ---
+AllCops:
+  TargetRubyVersion: 2.3
+
 Style/GlobalVars:
   AllowedVariables: [ $logger, $settings, $git_repo, $tmpdir ]
 Metrics/LineLength:
@@ -20,3 +23,6 @@ Style/ClassCheck:
 Style/RedundantSelf:
   Exclude:
     - lib/domain.rb
+Metrics/BlockLength:
+  Exclude:
+    - spec/**

--- a/Rakefile
+++ b/Rakefile
@@ -1,9 +1,17 @@
+# frozen_string_literal: true
+
 require 'rubocop/rake_task'
 
 RuboCop::RakeTask.new
 
 desc 'Run everything test related'
-task travis: :rubocop
+task travis: %i[rubocop]
+
+# RSpec::Core::RakeTask.new(:spec) do |config|
+#   config.rspec_opts = '--format doc'
+# end
+# RSpec::Core::RakeTask.new(:"spec:integration") do |config|
+# end
 
 task :default do
   puts 'There are not test yet. Sorry'

--- a/bin/miq-workflow
+++ b/bin/miq-workflow
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
+
 require 'thor'
 require_relative '../lib/bootstrap.rb'
 require_relative '../lib/cli/cli.rb'

--- a/lib/bootstrap.rb
+++ b/lib/bootstrap.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rugged'
 require 'tmpdir'
 require 'logger'

--- a/lib/cli/cli.rb
+++ b/lib/cli/cli.rb
@@ -1,4 +1,5 @@
-#!/usr/bin/env ruby
+# frozen_string_literal: true
+
 require 'thor'
 require_relative 'list.rb'
 

--- a/lib/cli/list.rb
+++ b/lib/cli/list.rb
@@ -1,4 +1,5 @@
-#!/usr/bin/env ruby
+# frozen_string_literal: true
+
 require 'thor'
 
 module GitFlow

--- a/lib/domain.rb
+++ b/lib/domain.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module GitFlow
   # Represents a single ManageIQ Automate Domain on disk
   class MiqDomain

--- a/lib/feature.rb
+++ b/lib/feature.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'pathname'
 require_relative 'domain.rb'
 

--- a/lib/gitflow.rb
+++ b/lib/gitflow.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Global Methods
 module GitFlow
   include GitFlow::Settings

--- a/lib/manageiq.rb
+++ b/lib/manageiq.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module GitFlow
   # Implements API calls to ManageIQ
   class ManageIQ

--- a/lib/miq/method_clean.rb
+++ b/lib/miq/method_clean.rb
@@ -1,5 +1,8 @@
+# frozen_string_literal: true
+
 require 'tmpdir'
 require 'yaml'
+
 module GitFlow
   # This module contains everything needed to prepare an Automate domain for import
   # Mostly file handling at this point

--- a/lib/miq/method_partial.rb
+++ b/lib/miq/method_partial.rb
@@ -1,5 +1,8 @@
+# frozen_string_literal: true
+
 require 'tmpdir'
 require 'yaml'
+
 module GitFlow
   # This module contains everything needed to prepare an Automate domain for import
   # Mostly file handling at this point

--- a/lib/miq/mixin_miq.rb
+++ b/lib/miq/mixin_miq.rb
@@ -1,10 +1,12 @@
+# frozen_string_literal: true
+
 require 'pathname'
 require 'yaml'
 module GitFlow
   module MiqMethods
     # ManageIQ related Methods, that are not plugable
     module MiqUtils
-      DOMAIN_FILE_NAME = '__domain__.yaml'.freeze
+      DOMAIN_FILE_NAME = '__domain__.yaml'
 
       # Find and read Automate domains
       # Search PATH for __domain__.yaml files, indicating a ManageIQ Automate Domain

--- a/lib/miq/provider_docker.rb
+++ b/lib/miq/provider_docker.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module GitFlow
   module MiqProvider
     # This Provider uses 'docker exec' to communicate to ManageIQ

--- a/lib/miq/provider_local.rb
+++ b/lib/miq/provider_local.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module GitFlow
   module MiqProvider
     # This provider assumes to be running on a ManageIQ Appliance

--- a/lib/miq/provider_noop.rb
+++ b/lib/miq/provider_noop.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module GitFlow
   # MiqProvider implement the actual communication to ManageIQ
   # This depends the choosen deployment scenario for ManageIQ (e.g. Appliance)

--- a/lib/mixin_api.rb
+++ b/lib/mixin_api.rb
@@ -1,5 +1,8 @@
+# frozen_string_literal: true
+
 require 'rest-client'
 require 'json'
+
 module GitFlow
   # ManageIQ API related stuff
   module ApiMethods

--- a/lib/mixin_git.rb
+++ b/lib/mixin_git.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rugged'
 
 module GitFlow

--- a/lib/mixin_settings.rb
+++ b/lib/mixin_settings.rb
@@ -1,4 +1,5 @@
-# Global Methods
+# frozen_string_literal: true
+
 module GitFlow
   # This mixin handles configuration updates
   # Every update_* method only modifies he config if a


### PR DESCRIPTION
This change enforces the magic comment '# frozen_string_literal: true' to
be present in all ruby files. The magic comment enforces a breaking change
in ruby 3.0